### PR TITLE
Fix/background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 - [X] Update colors in header when at the top of the page
 - [X] Change footer
   - [ ] Replace placeholder icon with ghost bunny icon
+- [ ] Change background under hero
 - [ ] Hide logo while hero is on top
 - [X] Remove all posts except for one
-- [ ] Set last post to placeholder post
+- [X] Set last post to placeholder post
+- [ ] Edit initial post
 - [ ] Change site preview
 - [ ] content/meta/config.js - change siteUrl when we have custom domain
 - [ ] content/meta/config.js - change siteImage to a jpg of finished site

--- a/src/components/Blog/Blog.js
+++ b/src/components/Blog/Blog.js
@@ -26,6 +26,7 @@ const Blog = props => {
       <style jsx>{`
         .main {
           padding: 0 ${theme.space.inset.default};
+          background-color: ${theme.color.brand.primaryBackground};
         }
 
         ul {

--- a/src/components/Blog/Item.js
+++ b/src/components/Blog/Item.js
@@ -33,7 +33,7 @@ const Item = props => {
       <li>
         <Link to={slug} key={slug} className="link">
           <div className="gatsby-image-outer-wrapper">
-            <Img fluid={fluid} />
+            <Img fluid={fluid} style={{zIndex: 1}} />
           </div>
           <h1>
             {title} <FaArrowRight className="arrow" />

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -19,6 +19,7 @@ const Footer = props => {
           padding: ${theme.space.inset.default};
           padding-top: 0;
           padding-bottom: 60px;
+          margin-top: 20px;
 
           :global(.gatsby-resp-image-wrapper) {
             width: 30px;

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -148,7 +148,8 @@ class Menu extends React.Component {
         <nav className={`menu ${open ? "open" : ""}`} rel="js-menu">
           <ul className="itemList" ref={this.itemList}>
             {this.items.map(item => (
-              <Item size={iconSize} item={item} key={item.label} icon={item.icon} theme={theme} />
+              //set key to icon since both labels are empty strings
+              <Item size={iconSize} item={item} key={item.icon} icon={item.icon} theme={theme} />
             ))}
           </ul>
           {this.state.hiddenItems.length > 0 && <Expand onClick={this.toggleMenu} theme={theme} />}


### PR DESCRIPTION
- Change background color of main section to ```theme.color.brand.primaryBackground```
- Add ```margin-top``` to footer to even out spacing
- Force ```zIndex: 1``` on gatsby Img since the -1 z-index was causing the background color to cover the image when mouse is not hovering over image.