### PR TITLE
Change url in meta tag in react helmet, was adding two undefineds to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,16 @@
 - [X] Set last post to placeholder post
 - [X] Add twitter icon
 - [ ] Edit initial post
-- [ ] Change site preview
+- [ ] Change site preview - unsure why when sharing site through text still showing old preview
 - [X] content/meta/config.js - change siteUrl when we have custom domain
 - [ ] content/meta/config.js - change siteImage to a jpg of finished site
 - [X] content/meta/config.js - set twitter handle
 - [X] content/meta/config.js - set instagram handle
 - [ ] content/meta/config.js - set youtube handle
 - [ ] Change the rest of the readme or delete?
+
+### Bugs
+- [ ] When shared by text, goes to doughnut-daze.com/undefinedundefined
 
 ### low priority
 - [ ] Add google analytics

--- a/src/components/Seo/Seo.js
+++ b/src/components/Seo/Seo.js
@@ -13,7 +13,10 @@ const Seo = props => {
   const title = postTitle ? `${postTitle} - ${config.shortSiteTitle}` : config.siteTitle;
   const description = postDescription ? postDescription : config.siteDescription;
   const image = postCover ? postCover : config.siteImage;
-  const url = config.siteUrl + config.pathPrefix + postSlug;
+  // below was giving a url of doughnut-daze.com/undefinedundefined
+  // no pathPrefix is set in config, also no postSlug exists for homepage
+  // leaving it in block comment in case it is useful for blog post links
+  const url = config.siteUrl /*+ config.pathPrefix + postSlug;*/
 
   return (
     <Helmet


### PR DESCRIPTION
…the path

Found this bug from sharing the site from my phone. Hitting share in safari and sending the link through text would go to ```https://doughnut-daze.com/undefinedundefined``` instead of just ```https://doughnut-daze.com/```, and show an unintended 404.

Originally the react-helmet was setting url to ```config.siteUrl + config.pathPrefix + postSlug;```, but ```config.pathPrefix``` doesn't exist (error in the starter?) and ```postSlug``` doesn't exist since the main page isn't pointing to an individual post.

This would set the url to ```https://doughnut-daze.com/undefinedundefined```. For now commented out ```config.pathPrefix``` and ```postSlug``` in case it is useful for other pages or I misunderstand how they should be used.